### PR TITLE
Fixed list parser expecting content as a stringn instead of a ListIte…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "editor-react-parser",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "editor-react-parser",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "license": "BSD-3-Clause",
       "dependencies": {
         "html-react-parser": "^5.2.3",
-        "react": "^19.1.0",
+        "react": "19.1.0",
+        "react-dom": "19.1.0",
         "react-syntax-highlighter": "^15.6.1"
       },
       "devDependencies": {
@@ -5386,9 +5387,7 @@
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -5719,9 +5718,7 @@
       "version": "0.26.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
       "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "6.3.1",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
   },
   "dependencies": {
     "html-react-parser": "^5.2.3",
-    "react": "^19.1.0",
+    "react": "19.1.0",
+    "react-dom": "19.1.0",
     "react-syntax-highlighter": "^15.6.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "editor-react-parser",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "A renderer for editorjs block data for react",
   "main": "dist/BlockParser.js",
   "types": "dist/BlockParser.d.ts",

--- a/src/BlockParsers/list.tsx
+++ b/src/BlockParsers/list.tsx
@@ -1,14 +1,30 @@
 import React from "react";
-import {OutputBlockData} from "../BlockParser";
+import { OutputBlockData } from "../BlockParser";
 
 /**
  * Output of a list block
  */
 
-export type EditorJsList = {
-    style: ListStyle,
-    items: string[]
+export interface ListItem {
+    /**
+     * list item text content
+     */
+    content: string;
+    /**
+     * Meta information of each list item
+     */
+    meta: object;
+    /**
+     * sublist items
+     */
+    items: ListItem[];
 }
+
+export type EditorJsList = {
+    style: ListStyle;
+    meta: object;
+    items: ListItem[] | string[];
+};
 
 export enum ListStyle {
     ordered = "ordered",
@@ -17,33 +33,77 @@ export enum ListStyle {
 
 export type ListConfig = {
     classNames: {
-        unordered?: string,
-        ordered?: string
-    }
-}
+        unordered?: string;
+        ordered?: string;
+    };
+};
 
 const defaultListConfig: ListConfig = {
     classNames: {
         unordered: "list-disc ml-7",
         ordered: "list-decimal ml-7",
-    }
-}
+    },
+};
 
 export interface ListProps {
-    item: OutputBlockData<EditorJsList>,
-    config?: ListConfig
+    item: OutputBlockData<EditorJsList>;
+    config?: ListConfig;
 }
 
-const ListBlock = ({item, config}: ListProps): React.JSX.Element => {
-    const currentClasses = Object.assign({}, defaultListConfig, config).classNames
-    const listElements: React.JSX.Element[] = item.data.items.map((text: string, index: number) =>
-        <li className={
-            item.data.style == ListStyle.unordered ? currentClasses.unordered : currentClasses.ordered}
-            key={index + text}>{text}</li>)
+const ListBlock = ({ item, config }: ListProps): React.JSX.Element => {
+    const currentClasses = Object.assign(
+        {},
+        defaultListConfig,
+        config
+    ).classNames;
+    const listElements: React.JSX.Element[] = item.data.items.map(
+        (text: ListItem | string, index: number) => {
+            if (typeof text === "string") {
+                return (
+                    <li
+                        className={
+                            item.data.style == ListStyle.unordered
+                                ? currentClasses.unordered
+                                : currentClasses.ordered
+                        }
+                        key={index + text}
+                    >
+                        {text}
+                    </li>
+                );
+            }
+            return (
+                <li
+                    className={
+                        item.data.style == ListStyle.unordered
+                            ? currentClasses.unordered
+                            : currentClasses.ordered
+                    }
+                    key={index + text.content}
+                >
+                    {text.content}
+                    {text.items.length > 0 && (
+                        <ListBlock
+                            item={{
+                                data: {
+                                    style: item.data.style,
+                                    meta: item.data.meta,
+                                    items: text.items,
+                                },
+                                type: "list",
+                            }}
+                            config={config}
+                        />
+                    )}
+                </li>
+            );
+        }
+    );
+
     if (item.data.style === ListStyle.ordered) {
-        return <ol key={item.id}>{listElements}</ol>
+        return <ol key={item.id}>{listElements}</ol>;
     } else {
-        return <ul key={item.id}>{listElements}</ul>
+        return <ul key={item.id}>{listElements}</ul>;
     }
 };
 


### PR DESCRIPTION
Given the React error complaining that list must use map function instead of rendering the object...
1. Fixed list parser expecting list item content as a string instead of a ListItem object. Now it accepts both.
2. Added primitive nested list rendering which at least partially covers a feature request (see https://github.com/cevinw/editorjs-react-parser/issues/3)