### PR TITLE
Improvements for Quote and Image parsers

### DIFF
--- a/src/BlockParsers/image.tsx
+++ b/src/BlockParsers/image.tsx
@@ -21,8 +21,8 @@ export type ImageConfig = {
         image?: string,
     },
     dimensions?: {
-        width?: number,
-        height?: number,
+        width?: number | string,
+        height?: number | string,
     },
 }
 
@@ -47,8 +47,7 @@ const ImageBlock = ({item, config}: ImageProps) : React.JSX.Element  => {
     return <section className={currentConfig.classNames?.container}>
         <img className={currentConfig.classNames?.image}
                alt={item.data.caption}
-               width={currentConfig.dimensions?.width}
-               height={currentConfig.dimensions?.height}
+               style={{ width: currentConfig.dimensions?.width, height: currentConfig.dimenstions?.height}}
                src={item.data.file.url}
         />
     </section>

--- a/src/BlockParsers/quote.tsx
+++ b/src/BlockParsers/quote.tsx
@@ -15,6 +15,7 @@ export enum QuoteAlignment {
     left = "left",
     center = "center",
     right = "right",
+    justify="justify"
 }
 
 export type QuoteConfig = {
@@ -22,6 +23,7 @@ export type QuoteConfig = {
         alignCenter?: string,
         alignRight?: string,
         alignLeft?: string,
+        alignJustify?: string,
         quote?: string,
         caption?: string,
     }
@@ -32,6 +34,7 @@ const defaultQuoteConfig: QuoteConfig = {
         alignCenter: "text-center",
         alignRight: "text-right",
         alignLeft: "text-left",
+        alignJustify: "text-left",
         quote: "italic text-lg",
         caption: "opacity-85 text-sm"
     }
@@ -48,6 +51,7 @@ const QuoteBlock = ({item, config}: QuoteProps): React.JSX.Element => {
         [QuoteAlignment.left]: currentConfig.classNames.alignLeft,
         [QuoteAlignment.center]: currentConfig.classNames.alignCenter,
         [QuoteAlignment.right]: currentConfig.classNames.alignRight,
+        [QuoteAlignment.justify]: currentConfig.classNames.alignJustify
     }[item.data.alignment]}><span
         className={currentConfig.classNames.quote}>&quot;{item.data.text}&quot;</span><br/><span
         className={currentConfig.classNames.caption}>- {item.data.caption}</span></p>

--- a/src/BlockParsers/quote.tsx
+++ b/src/BlockParsers/quote.tsx
@@ -34,7 +34,7 @@ const defaultQuoteConfig: QuoteConfig = {
         alignCenter: "text-center",
         alignRight: "text-right",
         alignLeft: "text-left",
-        alignJustify: "text-left",
+        alignJustify: "text-justify",
         quote: "italic text-lg",
         caption: "opacity-85 text-sm"
     }


### PR DESCRIPTION
1. Extended Quote block parser to accept `align: justify`.
2. Fixed Image block parser to accept image width and height config as both number and string to use other than px unit measurements.